### PR TITLE
Modified forsiv3D

### DIFF
--- a/src/Option/AudioManager.hpp
+++ b/src/Option/AudioManager.hpp
@@ -45,8 +45,8 @@ private:
 	std::shared_ptr<class Settings> m_settings;
 
 	// 音源の実体
-	std::unordered_map<String, Audio> m_bgmMap;
-	std::unordered_map<String, Audio> m_seMap;
+	HashTable<String, Audio> m_bgmMap;
+	HashTable<String, Audio> m_seMap;
 
 	String m_currentBGMId;
 


### PR DESCRIPTION
c++のunordered_mapが、siv3DだとHashTabeで定義されていたので変更しました。動作などで変わった部分はないです。